### PR TITLE
Add alpine nix docker config

### DIFF
--- a/alpine-nix/Dockerfile
+++ b/alpine-nix/Dockerfile
@@ -1,0 +1,52 @@
+# dkubb/alpine-nix
+
+FROM alpine:3.2
+MAINTAINER Dan Kubb <dkubb@fastmail.com>
+
+ENV NIX_VERSION 1.9
+ENV NIX_SHA256  8a47cd7c35dfa628a4acfaef387e7451013c61d250bbcf1f38067a7c73f9f3e1
+
+# Upgrade installed system dependencies
+COPY apk-packages /tmp/
+RUN sed 's/#.*$//;/^$/d' /tmp/apk-packages | tr -d ' ' | xargs apk add --update-cache
+
+ENV CC       x86_64-alpine-linux-musl-gcc
+ENV CXX      x86_64-alpine-linux-musl-g++
+ENV CFLAGS   -static
+ENV CXXFLAGS -static
+
+# Install WWW::Curl perl module (until perl-www-curl package is available)
+RUN perl -MCPAN -e 'install WWW::Curl'
+
+# Add patch to fix build errors
+COPY nix.patch /tmp/
+
+# Install nix from source
+RUN cd /tmp \
+  && curl --remote-name "https://nixos.org/releases/nix/latest/nix-$NIX_VERSION.tar.xz" \
+  && echo "$NIX_SHA256  nix-$NIX_VERSION.tar.xz" | shasum --algorithm 256 --check \
+  && tar xJf "nix-$NIX_VERSION.tar.xz" \
+  && cd "/tmp/nix-$NIX_VERSION" \
+  && patch -p1 < /tmp/nix.patch \
+  && ./bootstrap.sh \
+  && ./configure --sysconfdir=/etc --enable-gc \
+  && make \
+  && make install \
+  && rm -r /tmp/*
+
+# Create dummy user and group for nix
+RUN addgroup -S nixbld
+RUN adduser -DHS -G nixbld nixbld
+
+# NOTE: the /nix/store and /nix/store/trash directories need to be setup at the
+# same time in order for symlinks to be renamed between them. Otherwise EXDEV
+# errors are thrown, which is not handled properly by nix.
+
+# Setup nix for root user
+RUN mkdir -p -m 1755 /nix/store/trash \
+  && echo 'https://nixos.org/channels/nixpkgs-unstable nixpkgs' > /root/.nix-channels \
+  && nix-channel --update \
+  && ln -s /nix/var/nix/profiles/default /root/.nix-profile
+
+ENTRYPOINT ["/bin/bash", "--login", "-c"]
+CMD ["bash"]

--- a/alpine-nix/README.md
+++ b/alpine-nix/README.md
@@ -1,0 +1,19 @@
+# alpine-nix
+
+A docker container that compiles and installs nix on Alpine Linux.
+
+## Building
+
+```bash
+# Move to parent directory
+cd ..
+
+# Build the docker images
+./build.sh
+```
+
+## Verification
+
+```bash
+docker run -it --rm dkubb/alpine-nix
+```

--- a/alpine-nix/apk-packages
+++ b/alpine-nix/apk-packages
@@ -1,0 +1,33 @@
+# system dependencies
+alpine-base       = 3.2.3-r0
+alpine-baselayout = 2.3.2-r0
+alpine-conf       = 3.2.1-r6
+apk-tools         = 2.6.3-r0
+libcrypto1.0      = 1.0.2d-r0
+libssl1.0         = 1.0.2d-r0
+musl              = 1.1.9-r5
+musl-utils        = 1.1.9-r5
+openrc            = 0.15.1-r3
+
+# dockerfile dependencies
+curl              = 7.42.1-r0
+
+# nix dependencies
+autoconf          = 2.69-r0
+automake          = 1.15-r0
+bash              = 4.3.33-r0
+bison             = 3.0.4-r0
+bzip2-dev         = 1.0.6-r3
+curl-dev          = 7.42.1-r0
+flex              = 2.5.39-r0
+g++               = 4.9.2-r5
+gc-dev            = 7.4.2-r0
+gcc               = 4.9.2-r5
+libbz2            = 1.0.6-r3
+make              = 4.1-r0
+openssl-dev       = 1.0.2d-r0
+perl-dbd-sqlite   = 1.46-r0
+perl-dev          = 5.20.2-r0
+pkgconfig         = 0.25-r1
+sqlite-dev        = 3.8.10.2-r0
+xz                = 5.2.1-r0

--- a/alpine-nix/nix.patch
+++ b/alpine-nix/nix.patch
@@ -1,0 +1,22 @@
+--- nix-1.9.orig/Makefile
++++ nix-1.9/Makefile
+@@ -21,7 +21,6 @@
+   misc/launchd/local.mk \
+   misc/upstart/local.mk \
+   misc/emacs/local.mk \
+-  doc/manual/local.mk \
+   tests/local.mk
+
+ GLOBAL_CXXFLAGS += -std=c++0x -g -Wall
+--- nix-1.9.orig/src/libutil/affinity.cc
++++ nix-1.9/src/libutil/affinity.cc
+@@ -1,6 +1,9 @@
+ #include "types.hh"
+ #include "util.hh"
+ #include "affinity.hh"
++#include <string.h>
++
++#undef HAVE_SCHED_SETAFFINITY
+
+ #if HAVE_SCHED_H
+ #include <sched.h>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -feuo pipefail
+IFS=$'\n\t'
+
+readonly IMAGES=(
+  alpine-nix
+)
+
+for image in "${IMAGES[@]}"; do
+  (cd "$image"; docker build --tag "dkubb/$image" .)
+done


### PR DESCRIPTION
This branch adds dkubb/alpine-nix, which is Alpine Linux with Nix as a package manager.

I compiled Nix by hand and have it setup so the root user installs nix packages, but they are usable for all users. Based on what I know about NixOS, and not having used it, this is how I imagine it is installed and functional on that operating system.

Ultimately the goal is to build a docker container that can be used to statically link all the binaries and to musl rather than glibc (something the Nix toolchain doesn't allow yet, I think). Then the binaries can be copied directly to a bare bones Alpine Linux container with _no_ other build or runtime dependencies.
