### PR TITLE
Change default database to be postgres

### DIFF
--- a/alpine-nix-rails-nginx/Dockerfile
+++ b/alpine-nix-rails-nginx/Dockerfile
@@ -18,6 +18,7 @@ RUN nix-env --install \
     libxslt-1.1.28 \
     nginx-1.9.4 \
     nodejs-0.12.7 \
+    postgresql-9.4.4 \
     ruby-2.2.2-p0 \
     runit-2.1.2 \
     zlib-1.2.8 \
@@ -46,6 +47,7 @@ WORKDIR /opt/rails
 USER rails
 RUN source /etc/profile.d/nix.sh \
   && bundle config --local build.nokogiri '--use-system-libraries --with-xml2-include=/nix/var/nix/profiles/default/include/libxml2 --with-xml2-dir=/nix/var/nix/profiles/default --with-xslt-dir=/nix/var/nix/profiles/default' \
+  && bundle config --local build.pg '--use-system-libraries --with-zlib-dir=/nix/var/nix/profiles/default' \
   && bundle config --local build.puma '--use-system-libraries --with-opt-dir=/nix/var/nix/profiles/default'
 
 USER root

--- a/alpine-nix-rails-nginx/example-rails-template.rb
+++ b/alpine-nix-rails-nginx/example-rails-template.rb
@@ -26,16 +26,42 @@ file 'Procfile', <<-'PROCFILE'
 web: bundle exec puma --quiet --config config/puma.rb
 PROCFILE
 
+file 'config/postgres.sh', <<-'POSTGRES'
+#!/usr/bin/env bash
+
+set -o errexit -o pipefail -o noglob -o noclobber -o nounset
+IFS=$'\n\t'
+
+export PATH="/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:$PATH"
+
+exec chpst -u postgres -- postgres -D $PGDATA
+POSTGRES
+
 file 'Dockerfile', <<-'DOCKERFILE'
 FROM dkubb/alpine-nix-rails-nginx:latest
 MAINTAINER Dan Kubb <dkubb@fastmail.com>
 
 ENV RAILS_ENV development
+ENV PGDATA    /var/lib/postgresql/data
 
-RUN nix-env --install sqlite-3.8.11.1
-
+COPY config/postgres.sh /etc/sv/postgres
 RUN source /etc/profile.d/nix.sh \
-  && bundle config --local build.sqlite3 '--use-system-libraries --with-zlib-dir=/nix/var/nix/profiles/default --with-sqlite3-dir=/nix/var/nix/profiles/default'
+  && /root/setup-directories.sh root /etc/sv /etc/service/postgres \
+  && /root/setup-directories.sh postgres "$(dirname "$PGDATA")" "$PGDATA" \
+  && chmod u+x /etc/sv/postgres \
+  && ln -s -- /etc/sv/postgres /etc/service/postgres/run
+
+# Setup default user and database
+USER postgres
+RUN source /etc/profile.d/nix.sh \
+  && pg_ctl initdb --pgdata $PGDATA \
+  && pg_ctl start --pgdata $PGDATA \
+  && until psql --command 'SELECT 1' 2>/dev/null >&2; do :; done \
+  && createuser rails \
+  && createdb --owner rails example_development \
+  && pg_ctl stop --pgdata $PGDATA
+
+USER root
 
 # TODO: use the bundix tool to package up Gemfile deps, see:
 # https://nixos.org/nixpkgs/manual/#sec-language-ruby

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ readonly IMAGES=(
   alpine-nix-rails-nginx/example
 )
 
-(cd alpine-nix-rails-nginx && rails new example --template example-rails-template.rb --force)
+(cd alpine-nix-rails-nginx && rails new example --template example-rails-template.rb --database postgresql --force)
 
 for image in "${IMAGES[@]}"; do
   (cd "$(dirname "$0")/$image" && docker build --tag "dkubb/$image" .)


### PR DESCRIPTION
This branch changes rails configuration to use postgres instead of sqlite.

The main reason I did this is because my rails based docker images are basically _always_ going to use postgres, so I saw no reason not to push it down to my base docker image rather than duplicate that logic in every "child" image.

This should be merged after #4
