### PR TITLE
Remove special handling of maintenance page

### DIFF
--- a/alpine-nix-rails-nginx/etc/nginx/maintenance.conf
+++ b/alpine-nix-rails-nginx/etc/nginx/maintenance.conf
@@ -1,8 +1,0 @@
-# Set the default service unavailable page
-set $service_unavailable_page service_unavailable.html;
-
-# Display maintenance page if it exists
-if (-f $document_root/maintenance.html) {
-  set $service_unavailable_page maintenance.html;
-  return 503;
-}

--- a/alpine-nix-rails-nginx/etc/nginx/nginx.conf
+++ b/alpine-nix-rails-nginx/etc/nginx/nginx.conf
@@ -81,7 +81,7 @@ http {
 
   error_page 500 /internal_server_error.html;
   error_page 502 /bad_gateway.html;
-  error_page 503 @service_unavailable;
+  error_page 503 /service_unavailable.html;
   error_page 504 /gateway_timeout.html;
 
   # Catch-all domain

--- a/alpine-nix-rails-nginx/etc/nginx/server.conf
+++ b/alpine-nix-rails-nginx/etc/nginx/server.conf
@@ -8,21 +8,14 @@ location / {
 
 # Handle requests for dynamic content
 location ~ ^/(?:login|signup)/?$ {
-  include maintenance.conf;
   include dynamic-content.conf;
   proxy_pass http://rails;
 }
 
 # Handle requests for cacheable content
 location @rails {
-  include maintenance.conf;
   proxy_pass  http://rails;
   proxy_cache cacheable;
-}
-
-# Handle 503 Service Unavailable errors
-location @service_unavailable {
-  rewrite .* /$service_unavailable_page break;
 }
 
 # Handle nginx stub status


### PR DESCRIPTION
With docker it should not be necessary to configure the maintenance page in this manner. Given that the docker container will essentially be immutable it won't be possible to copy a maintenance.html page in place temporarily.
