### PR TITLE
Fix the Host header passed onto the backend server

### DIFF
--- a/alpine-nix-rails-nginx/etc/nginx/nginx.conf
+++ b/alpine-nix-rails-nginx/etc/nginx/nginx.conf
@@ -57,7 +57,7 @@ http {
   proxy_cache_revalidate on;
   proxy_intercept_errors on;
   proxy_http_version     1.1;
-  proxy_set_header       Host              $host;
+  proxy_set_header       Host              $http_host;
   proxy_set_header       X-Forwarded-For   $proxy_add_x_forwarded_for;
   proxy_set_header       X-Forwarded-Proto $scheme;
   proxy_set_header       X-Real-IP         $remote_addr;


### PR DESCRIPTION
- The problem with using $host is that it doesn't pass-through the port
  number, which is necessary if you are testing things on a non-standard
  port, which is often the case with docker. This change makes sure the
  host _and_ port are passed-through.
  
  The only reason $host is recommended in a few places is because if
  your default host is proxying resources the Host header may not be set
  to anything, causing something blank to be provided to the backend
  server. That's not the case with us since our default server _always_
  redirects to the canonical server and never proxies anything.
