### PR TITLE
Add missing font-src 'self' directive to CSP header

### DIFF
--- a/alpine-rails-nginx/etc/nginx/nginx.conf
+++ b/alpine-rails-nginx/etc/nginx/nginx.conf
@@ -66,7 +66,7 @@ http {
 
   more_set_headers "X-Content-Type-Options: nosniff";
   more_set_headers "X-Frame-Options: deny";
-  more_set_headers "Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; frame-ancestors 'none'"
+  more_set_headers "Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self'; frame-ancestors 'none'"
 
   more_set_headers "X-XSS-Protection: 1; mode=block";
   more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";


### PR DESCRIPTION
This branch adds missing directive for font src handling in CSP header.
