### PR TITLE
Change alpine-ruby container to use alpine 3.3

### DIFF
--- a/alpine-rails-nginx/apk-packages
+++ b/alpine-rails-nginx/apk-packages
@@ -1,5 +1,5 @@
 # nginx build dependencies
-linux-headers = 4.4.6-r1
+linux-headers = 4.1.12-r0
 pcre-dev      = 8.38-r0
 
 # service runtime dependencies
@@ -7,5 +7,5 @@ acl           = 2.2.52-r2
 libffi-dev    = 3.2.1-r2
 libxml2-dev   = 2.9.3-r0
 libxslt-dev   = 1.1.28-r2
-nodejs        = 5.10.1-r0
-openssl-dev   = 1.0.2g-r3
+nodejs        = 4.3.0-r0
+openssl-dev   = 1.0.2g-r0

--- a/alpine-rails-nginx/example-rails-template.rb
+++ b/alpine-rails-nginx/example-rails-template.rb
@@ -40,7 +40,7 @@ MAINTAINER Dan Kubb <dkubb@fastmail.com>
 ENV RAILS_ENV=development \
   PGDATA=/var/db/postgresql/data
 
-RUN apk add postgresql-dev=9.5.2-r1 \
+RUN apk add postgresql-dev=9.4.6-r0 \
   && chown postgres: /usr/bin/postgres \
   && chmod 0700 /usr/bin/postgres
 

--- a/alpine-ruby/Dockerfile
+++ b/alpine-ruby/Dockerfile
@@ -1,6 +1,6 @@
 # dkubb/alpine-ruby
 
-FROM alpine:edge
+FROM alpine:3.3
 MAINTAINER Dan Kubb <dkubb@fastmail.com>
 
 # Upgrade installed system dependencies

--- a/alpine-ruby/apk-packages
+++ b/alpine-ruby/apk-packages
@@ -1,19 +1,19 @@
 # system runtime dependencies
-alpine-base         = 3.3.0-r0
+alpine-base         = 3.3.3-r0
 alpine-baselayout   = 2.3.2-r10
-alpine-conf         = 3.3.2-r1
-apk-tools           = 2.6.6-r1
-busybox             = 1.24.2-r2
-busybox-initscripts = 2.3-r6
-busybox-suid        = 1.24.2-r2
-musl                = 1.1.14-r8
-musl-utils          = 1.1.14-r8
-openrc              = 0.20.5-r0
+alpine-conf         = 3.3.2-r0
+apk-tools           = 2.6.5-r1
+busybox             = 1.24.1-r7
+busybox-initscripts = 2.3-r2
+busybox-suid        = 1.24.1-r7
+musl                = 1.1.12-r5
+musl-utils          = 1.1.12-r5
+openrc              = 0.19-r4
 
 # dockerfile build dependencies
 alpine-sdk          = 0.4-r3
 bash                = 4.3.42-r3
-curl                = 7.48.0-r0
+curl                = 7.47.0-r0
 
 # service runtime dependencies
 ruby                = 2.2.4-r0


### PR DESCRIPTION
This change to use the latest stable alpine should result in packages needing to be upgraded less often.
