### PR TITLE
Add alpine-aws container

### DIFF
--- a/alpine-aws/Dockerfile
+++ b/alpine-aws/Dockerfile
@@ -1,0 +1,13 @@
+# dkubb/alpine-aws
+
+FROM alpine:3.6
+MAINTAINER Dan Kubb <dkubb@fastmail.com>
+
+# Upgrade system dependencies
+RUN apk upgrade --update-cache --available
+
+# Install system dependencies
+RUN apk add --update-cache py2-pip=9.0.1-r1
+
+# Install aws cli
+RUN umask 022 && pip install awscli==1.11.109


### PR DESCRIPTION
Adds a small container capable to run `aws-cli`.

### Acceptance

Run the following and observe the print out of all S3 buckets.

```
docker run --interactive --tty --volume $HOME/.aws:/root/.aws dkubb/alpine-aws aws s3 ls
````